### PR TITLE
scoreboard score back to show

### DIFF
--- a/src/main/java/com/redlimerl/guiscalesplitter/GuiScaleScreen.java
+++ b/src/main/java/com/redlimerl/guiscalesplitter/GuiScaleScreen.java
@@ -177,9 +177,9 @@ public class GuiScaleScreen extends Screen {
             }
         }));
 
-        Supplier<Text> scoreboardScore = () -> Text.literal("Scoreboard Score : " + (GuiScaleSplitter.getOption("disableScoreboardScore") != 0 ? "Hide" : "Show"));
+        Supplier<Text> scoreboardScore = () -> Text.literal("Scoreboard Score : " + (GuiScaleSplitter.getOption("disableScoreboardScore", 0) != 0 ? "Hide" : "Show"));
         this.addDrawableChild(ButtonWidget.builder(scoreboardScore.get(), button -> {
-            GuiScaleSplitter.setOption("disableScoreboardScore", GuiScaleSplitter.getOption("disableScoreboardScore") != 0 ? 0 : 1);
+            GuiScaleSplitter.setOption("disableScoreboardScore", GuiScaleSplitter.getOption("disableScoreboardScore", 0) != 0 ? 0 : 1);
             GuiScaleScreen.this.saveButton.active = true;
             button.setMessage(scoreboardScore.get());
         }).dimensions(this.width / 2 - 152, this.height - 104, 150, 20).build());

--- a/src/main/java/com/redlimerl/guiscalesplitter/mixin/MixinInGameHud.java
+++ b/src/main/java/com/redlimerl/guiscalesplitter/mixin/MixinInGameHud.java
@@ -76,7 +76,7 @@ public class MixinInGameHud {
 
     @WrapOperation(method = "renderScoreboardSidebar(Lnet/minecraft/client/gui/DrawContext;Lnet/minecraft/scoreboard/ScoreboardObjective;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawText(Lnet/minecraft/client/font/TextRenderer;Lnet/minecraft/text/Text;IIIZ)I", ordinal = 2))
     public int onScoreboardScore(DrawContext instance, TextRenderer textRenderer, Text text, int x, int y, int color, boolean shadow, Operation<Integer> original) {
-        boolean activate = GuiScaleSplitter.getOption("disableScoreboardScore") != 0;
+        boolean activate = GuiScaleSplitter.getOption("disableScoreboardScore", 0) != 0;
         return activate ? instance.drawText(textRenderer, "", x, y, 0, shadow) : original.call(instance, textRenderer, text, x, y, color, shadow);
     }
 


### PR DESCRIPTION
Minecraft 1.21+ allows datapacks and servers to customize the scoreboard score component

Leaving this option to hide these components by default only results in people complaining about missing information on the scoreboard of those servers and datapacks